### PR TITLE
Ajout de TotalItemsExtension et configuration de Mercure

### DIFF
--- a/Rwayed/.env
+++ b/Rwayed/.env
@@ -46,18 +46,15 @@ ADMIN_EMAIL_ADDRESS=
 UPLOADS_BASE_URL=
 ###< app-config ###
 
-# mercure avec fichier local
-# JWT_KEY='aVerySecretKeyMercure'
-# ADDR='localhost:3000'
-# ALLOW_ANONYMOUS=1
-# CORS_ALLOWED_ORIGINS=*
-
 ###> symfony/mercure-bundle ###
 # See https://symfony.com/doc/current/mercure.html#configuration
 # The URL of the Mercure hub, used by the app to publish updates (can be a local URL)
-# MERCURE_URL=http://localhost:3000/.well-known/mercure
+ MERCURE_URL=
 # The public URL of the Mercure hub, used by the browser to connect
-# MERCURE_PUBLIC_URL=http://localhost:3000/.well-known/mercure
+ MERCURE_PUBLIC_URL=
 # The secret used to sign the JWTs
-# MERCURE_JWT_SECRET="!aVerySecretKeyMercure!"
+ MERCURE_JWT_SECRET=
+ JWT_KEY=
+ MERCURE_SUBSCRIBER_JWT_KEY=
+ MERCURE_PUBLISHER_JWT_KEY=
 ###< symfony/mercure-bundle ###

--- a/Rwayed/compose.override.yaml
+++ b/Rwayed/compose.override.yaml
@@ -1,1 +1,8 @@
 version: '3'
+
+services:
+###> symfony/mercure-bundle ###
+  mercure:
+    ports:
+      - "80"
+###< symfony/mercure-bundle ###

--- a/Rwayed/compose.yaml
+++ b/Rwayed/compose.yaml
@@ -1,1 +1,34 @@
-version: '3'
+version: "3.8"
+
+services:
+  http:
+    build:
+      context: .
+      dockerfile: /docker/server/Dockerfile
+    expose:
+      - "9000"
+      - "9003"
+    ports:
+      - "8000:80"
+    working_dir: /var/www/html
+    volumes:
+      - ./source:/var/www/html
+      - ./docker/server/apache/sites-enabled:/etc/apache2/sites-enabled
+      - ./docker/server/php/php.ini:/usr/local/etc/php/conf.d/extra-php-config.ini
+      - ./docker/xdebug/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
+    depends_on:
+      - database
+    networks:
+      - inner_net
+    environment:
+      MERCURE_SUBSCRIBER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+      MERCURE_PUBLISHER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+      PUBLISHER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+      SUBSCRIBER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+
+volumes:
+  mercure_data:
+  mercure_config:
+
+networks:
+  inner_net:

--- a/Rwayed/composer.json
+++ b/Rwayed/composer.json
@@ -24,6 +24,7 @@
         "symfony/http-client": "7.0.*",
         "symfony/intl": "7.0.*",
         "symfony/mailer": "7.0.*",
+        "symfony/mercure-bundle": "*",
         "symfony/mime": "7.0.*",
         "symfony/monolog-bundle": "^3.0",
         "symfony/notifier": "7.0.*",
@@ -94,7 +95,8 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "7.0.*"
+            "require": "7.0.*",
+            "docker": true
         }
     },
     "require-dev": {

--- a/Rwayed/composer.lock
+++ b/Rwayed/composer.lock
@@ -1478,6 +1478,79 @@
             "time": "2023-10-06T06:47:41+00:00"
         },
         {
+            "name": "lcobucci/jwt",
+            "version": "5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "08071d8d2c7f4b00222cc4b1fb6aa46990a80f83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/08071d8d2c7f4b00222cc4b1fb6aa46990a80f83",
+                "reference": "08071d8d2c7f4b00222cc4b1fb6aa46990a80f83",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.27.0",
+                "lcobucci/clock": "^3.0",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2.9",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^10.2.6"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/5.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2024-04-11T23:07:54+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.5.0",
             "source": {
@@ -4307,6 +4380,173 @@
                 }
             ],
             "time": "2024-02-03T21:34:19+00:00"
+        },
+        {
+            "name": "symfony/mercure",
+            "version": "v0.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mercure.git",
+                "reference": "304cf84609ef645d63adc65fc6250292909a461b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mercure/zipball/304cf84609ef645d63adc65fc6250292909a461b",
+                "reference": "304cf84609ef645d63adc65fc6250292909a461b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/deprecation-contracts": "^2.0|^3.0|^4.0",
+                "symfony/http-client": "^4.4|^5.0|^6.0|^7.0",
+                "symfony/http-foundation": "^4.4|^5.0|^6.0|^7.0",
+                "symfony/polyfill-php80": "^1.22",
+                "symfony/web-link": "^4.4|^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "lcobucci/jwt": "^3.4|^4.0|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0|^7.0",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0|^7.0",
+                "symfony/phpunit-bridge": "^5.2|^6.0|^7.0",
+                "symfony/stopwatch": "^4.4|^5.0|^6.0|^7.0",
+                "twig/twig": "^2.0|^3.0|^4.0"
+            },
+            "suggest": {
+                "symfony/stopwatch": "Integration with the profiler performances"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.6.x-dev"
+                },
+                "thanks": {
+                    "name": "dunglas/mercure",
+                    "url": "https://github.com/dunglas/mercure"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mercure\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Mercure Component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mercure",
+                "push",
+                "sse",
+                "updates"
+            ],
+            "support": {
+                "issues": "https://github.com/symfony/mercure/issues",
+                "source": "https://github.com/symfony/mercure/tree/v0.6.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dunglas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/mercure",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-08T12:51:34+00:00"
+        },
+        {
+            "name": "symfony/mercure-bundle",
+            "version": "v0.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mercure-bundle.git",
+                "reference": "e21ad84694b84c9a3c94bedf4edd82b66728abfc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mercure-bundle/zipball/e21ad84694b84c9a3c94bedf4edd82b66728abfc",
+                "reference": "e21ad84694b84c9a3c94bedf4edd82b66728abfc",
+                "shasum": ""
+            },
+            "require": {
+                "lcobucci/jwt": "^3.4|^4.0|^5.0",
+                "php": ">=7.1.3",
+                "symfony/config": "^4.4|^5.0|^6.0|^7.0",
+                "symfony/dependency-injection": "^4.4|^5.4|^6.0|^7.0",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0|^7.0",
+                "symfony/mercure": "^0.6.1",
+                "symfony/web-link": "^4.4|^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.3.7|^5.0|^6.0|^7.0",
+                "symfony/stopwatch": "^4.3.7|^5.0|^6.0|^7.0",
+                "symfony/ux-turbo": "*",
+                "symfony/var-dumper": "^4.3.7|^5.0|^6.0|^7.0"
+            },
+            "suggest": {
+                "symfony/messenger": "To use the Messenger integration"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\MercureBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony MercureBundle",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mercure",
+                "push",
+                "sse",
+                "updates"
+            ],
+            "support": {
+                "issues": "https://github.com/symfony/mercure-bundle/issues",
+                "source": "https://github.com/symfony/mercure-bundle/tree/v0.3.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dunglas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/mercure-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-03T22:26:24+00:00"
         },
         {
             "name": "symfony/messenger",

--- a/Rwayed/config/bundles.php
+++ b/Rwayed/config/bundles.php
@@ -16,4 +16,5 @@ return [
     Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle::class => ['dev' => true, 'test' => true],
     SymfonyCasts\Bundle\VerifyEmail\SymfonyCastsVerifyEmailBundle::class => ['all' => true],
     SymfonyCasts\Bundle\ResetPassword\SymfonyCastsResetPasswordBundle::class => ['all' => true],
+    Symfony\Bundle\MercureBundle\MercureBundle::class => ['all' => true],
 ];

--- a/Rwayed/config/packages/mercure.yaml
+++ b/Rwayed/config/packages/mercure.yaml
@@ -1,0 +1,8 @@
+mercure:
+    hubs:
+        default:
+            url: '%env(MERCURE_URL)%'
+            public_url: '%env(MERCURE_PUBLIC_URL)%'
+            jwt:
+                secret: '%env(MERCURE_JWT_SECRET)%'
+                publish: '*'

--- a/Rwayed/config/services.yaml
+++ b/Rwayed/config/services.yaml
@@ -17,6 +17,7 @@ services:
     _defaults:
         autowire: true      # Injecte automatiquement les dépendances dans vos services.
         autoconfigure: true # Enregistre automatiquement vos services comme commandes, abonnés à des événements, etc.
+        public: false       # (encapsule)interdit l'accès direct au service à l'extérieur du conteneur de services, mais permet toujours son utilisation en tant que dépendance injectée dans d'autres services.
         bind:               # Liaisons de paramètres spécifiques pour l'injection de dépendances
             $csrfTokenManager: '@security.csrf.token_manager'
             $apiPlatformClient: '@my.api.platform.client'
@@ -37,6 +38,11 @@ services:
         tags:
             - { name: 'kernel.event_subscriber' }
 
+    # App\EventListener\TotalItemsListener:
+    #     tags:
+    #         - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
+    #         - { name: kernel.event_listener, event: kernel.controller, method: onKernelController }        
+
     # Stratégies
     App\Strategy\PhotoStrategyInterface: '@App\Strategy\PhotoTransformationStrategy'
     App\Strategy\AvisStrategyInterface: '@App\Strategy\AvisTransformationStrategy'
@@ -51,29 +57,20 @@ services:
         factory: ['Symfony\Component\HttpClient\HttpClient', 'create']
         arguments:
             $defaultOptions:
-                base_uri: '%env(API_BASE_URL)%'
-
-
-    App\EventSubscriber\AuthenticationEventSubscriber:
-        arguments:
-            $authenticationUtils: '@security.authentication_utils'
-            $twig: '@twig'
-        tags:
-            - { name: 'kernel.event_subscriber' }
-    # default configuration for services in this file
-    App\Services\PasswordHasherService:
-        arguments:
-            $passwordHasher: '@Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface'
-
-    App\Services\WishlistService:
-        arguments:
-            $entityManager: '@doctrine.orm.entity_manager'
+                base_uri: '%env(API_BASE_URL)%'    
 
     # Enregistrement manuel de l'extension Twig comme service
 
     App\Twig\AppExtension:
         tags:
             - { name: twig.extension }
+            
+    App\Twig\TotalItemsExtension:
+        arguments:
+            $entityManager: '@doctrine.orm.entity_manager'
+            $security: '@security.helper'
+        tags: [twig.extension]
+
     App\Twig\MinioExtension:
         arguments:
             $uploadsBaseUrl: '%uploads_base_url%'

--- a/Rwayed/src/Controller/WishlistController.php
+++ b/Rwayed/src/Controller/WishlistController.php
@@ -2,48 +2,42 @@
 
 namespace App\Controller;
 
-use App\Entity\Pneu;
 use App\Entity\Adherent;
+use App\Entity\Pneu;
 use App\Entity\PneuFavList;
 use App\Services\WishlistService;
-// use Symfony\Component\Mercure\Update;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
-// use Symfony\Component\Mercure\PublisherInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class WishlistController extends AbstractController
 {
     private EntityManagerInterface $entityManager;
     private Security $security;
-    // private PublisherInterface $publisher;
     private $wishlistService;
 
     public function __construct(EntityManagerInterface $entityManager, Security $security, WishlistService $wishlistService)
     {
         $this->entityManager = $entityManager;
         $this->security = $security;
-        // $this->publisher = $publisher;
         $this->wishlistService = $wishlistService;
     }
 
-    // /**
-    //  * @Route("/wishlist", name="wishlist")
-    //  */
     #[Route('/wishlist', name: 'wishlist')]
     public function index(UrlGeneratorInterface $urlGenerator): Response
     {
         // Récupérer l'utilisateur connecté
         $user = $this->getUser();
 
-        if (!$this->security->isGranted('ROLE_ADHERENT') || !$user instanceof Adherent) {
+        //gestion ROLE_ADHERENT dans security.yaml
+        if (!$user instanceof Adherent) {
             // Rediriger les non connecter vers la page login
             return new RedirectResponse($urlGenerator->generate('login'));
         }
@@ -51,28 +45,19 @@ class WishlistController extends AbstractController
         $wishlist = $this->entityManager->getRepository(PneuFavList::class)->findBy([
             'adherent' => $user,
         ]);
-        // Calculer le nombre total d'éléments dans la liste de souhaits
-        $totalItems = count($wishlist);
 
-        // Publier le nombre total d'éléments via Mercure
-        // $this->publisher->__invoke(new Update(
-        //     '/wishlist/totalItems',
-        //     json_encode(['totalItems' => $totalItems])
-        // ));
-        
         return $this->render('wishlist.twig', [
             'wishlist' => $wishlist,
-            'totalItems' => $totalItems,
         ]);
     }
 
     #[Route('/wishlist/add/{id}', name: 'wishlist_add', methods: ['GET', 'POST'], options: ['expose' => true])]
-    public function addToWishlist(int $id, Request $request, UrlGeneratorInterface $urlGenerator): Response
+    public function addToWishlist(Pneu $pneu, Request $request, UrlGeneratorInterface $urlGenerator): Response
     {
         // Todo WishlistObserverCD  !!!!!!!!!!!!
         $user = $this->getUser();
-        
-        if (!$this->security->isGranted('ROLE_ADHERENT') || !$user instanceof Adherent) { 
+
+        if (!$user instanceof Adherent) {
             // Rediriger les non connectés vers la page de connexion
             return new RedirectResponse($urlGenerator->generate('login'));
         }
@@ -80,13 +65,7 @@ class WishlistController extends AbstractController
         // Vérifiez si la requête est AJAX
         if (!$request->isXmlHttpRequest()) {
             // Lancer une exception MethodNotAllowedException si la requête n'est pas AJAX
-            throw new MethodNotAllowedException(['POST'], 'This route is only accessible via AJAX');
-        }
-
-        // Check if the Pneu exists
-        $pneu = $this->entityManager->getRepository(Pneu::class)->find($id);
-        if (!$pneu) {
-            return new JsonResponse(['error' => 'The pneu does not exist'], 404);
+            throw new MethodNotAllowedException(['POST']);
         }
 
         // Ajouter le pneu à la liste de souhaits en utilisant le service
@@ -95,17 +74,16 @@ class WishlistController extends AbstractController
         if ($success) {
             return new JsonResponse(['success' => true]);
         } else {
-            return new JsonResponse(['error' => 'The pneu is already in your wishlist'], 409);
+            return new JsonResponse(['error' => 'The pneu is already in your wishlist'], Response::HTTP_CONFLICT);
         }
     }
 
-
     #[Route('/wishlist/remove/{id}', name: 'wishlist_remove', methods: ['POST'], options: ['expose' => true])]
-    public function removeFromWishlist(int $id, Request $request, UrlGeneratorInterface $urlGenerator): Response
+    public function removeFromWishlist(Pneu $pneu, Request $request, UrlGeneratorInterface $urlGenerator): Response
     {
         $user = $this->getUser();
 
-        if (!$this->security->isGranted('ROLE_ADHERENT') || !$user instanceof Adherent) {
+        if (!$user instanceof Adherent) {
             // Rediriger les utilisateurs non connectés vers la page de connexion
             return new RedirectResponse($urlGenerator->generate('login'));
         }
@@ -115,19 +93,13 @@ class WishlistController extends AbstractController
             return new JsonResponse(['error' => 'This route is only accessible via AJAX'], 400);
         }
 
-        // Récupérer le pneu à supprimer de la liste de souhaits
-        $pneu = $this->entityManager->getRepository(Pneu::class)->find($id);
-        if (!$pneu) {
-            return new JsonResponse(['error' => 'The pneu does not exist'], 404);
-        }
-
         // Utiliser le service pour supprimer le pneu de la liste de souhaits
         $success = $this->wishlistService->removeFromWishlist($user, $pneu);
 
         if ($success) {
             return new JsonResponse(['success' => true]);
         } else {
-            return new JsonResponse(['error' => 'The pneu is not in your wishlist'], 404);
+            return new JsonResponse(['error' => 'The pneu is not in your wishlist'], Response::HTTP_NOT_FOUND);
         }
     }
 }

--- a/Rwayed/src/Entity/Adherent.php
+++ b/Rwayed/src/Entity/Adherent.php
@@ -30,7 +30,7 @@ class Adherent extends Personne
         $this->points_fidelite = 0;
         $this->roles = ['ROLE_ADHERENT'];
 
-        $this->adresses = new ArrayCollection(
+        $this->adresses = new ArrayCollection();
         $this->pneuFavLists = new ArrayCollection();
         $this->avis = new ArrayCollection();
 

--- a/Rwayed/src/Services/WishlistService.php
+++ b/Rwayed/src/Services/WishlistService.php
@@ -18,15 +18,13 @@ class WishlistService
 
     public function addToWishlist(Adherent $user, Pneu $pneu): bool
     {
-        // Vérifier si le pneu est déjà dans la liste de souhaits de l'utilisateur
-        $wishlistEntry = $this->entityManager->getRepository(PneuFavList::class)->findOneBy([
-            'adherent' => $user,
-            'pneu' => $pneu,
-        ]);
-        if ($wishlistEntry) {
-            return false; // Le pneu est déjà dans la liste de souhaits
-        }
+        $pneuFavLists = $user->getPneuFavLists();
 
+        foreach ($pneuFavLists as $pneuFavList) {
+            if ($pneuFavList->getPneu() === $pneu) {
+                return false; // Le pneu est déjà dans la liste des favoris de l'utilisateur
+            }
+        }
         // Créer une nouvelle entité PneuFavList
         $pneuFavList = new PneuFavList();
         $pneuFavList->setAdherent($user);
@@ -42,20 +40,19 @@ class WishlistService
 
     public function removeFromWishlist(Adherent $user, Pneu $pneu): bool
     {
-        // Rechercher pneu correspondante dans la liste de souhaits de l'utilisateur
-        $wishlistEntry = $this->entityManager->getRepository(PneuFavList::class)->findOneBy([
-            'adherent' => $user,
-            'pneu' => $pneu,
-        ]);
+        $pneuFavLists = $user->getPneuFavLists();
 
-        // Si pneu existe, le supprimer
-        if ($wishlistEntry) {
-            $this->entityManager->remove($wishlistEntry);
-            $this->entityManager->flush();
-
-            return true;
-        } else {
-            return false;
+        foreach ($pneuFavLists as $pneuFavList) {
+            if ($pneuFavList->getPneu() === $pneu) {
+                // Supprimer le pneu de la liste de souhaits de l'utilisateur
+                $this->entityManager->remove($pneuFavList);
+                $this->entityManager->flush();
+                
+                return true;
+            }
         }
+
+        // Si le pneu n'est pas trouvé dans la liste de souhaits de l'utilisateur
+        return false;
     }
 }

--- a/Rwayed/src/Twig/TotalItemsExtension.php
+++ b/Rwayed/src/Twig/TotalItemsExtension.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Twig;
+
+use Twig\TwigFunction;
+use App\Entity\PneuFavList;
+use App\Entity\Adherent;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\ExtensionInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class TotalItemsExtension extends AbstractExtension implements ExtensionInterface
+{
+    private $entityManager;
+    private $security;
+
+    public function __construct(EntityManagerInterface $entityManager, Security $security)
+    {
+        $this->entityManager = $entityManager;
+        $this->security = $security;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('totalItems', [$this, 'getTotalItems']),
+        ];
+    }
+
+    public function getTotalItems()
+    {
+        $user = $this->security->getUser();
+
+        if ($user instanceof Adherent) {
+            return $this->entityManager->getRepository(PneuFavList::class)->count(['adherent' => $user]);
+        }
+
+        return 0; // Retourne 0 si l'utilisateur n'est pas connecté ou n'est pas un Adherent
+    }
+}

--- a/Rwayed/symfony.lock
+++ b/Rwayed/symfony.lock
@@ -155,6 +155,18 @@
             "ref": "fadbfe33303a76e25cb63401050439aa9b1a9c7f"
         }
     },
+    "symfony/mercure-bundle": {
+        "version": "0.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "0.3",
+            "ref": "d097c114aae82c5bc88d48ac164fe523f1003292"
+        },
+        "files": [
+            "config/packages/mercure.yaml"
+        ]
+    },
     "symfony/messenger": {
         "version": "7.0",
         "recipe": {

--- a/Rwayed/templates/base.twig
+++ b/Rwayed/templates/base.twig
@@ -243,7 +243,8 @@
 	z"/>
                                 </svg>
                             </span>
-                        <span class="indicator__counter">{{ totalItems }}</span>
+                            {# default(0) cas de totalItems() return null #}
+                        <span class="indicator__counter">{{ totalItems()|default(0) }}</span>
                     </a>
                 </div>
                 <div class="indicator indicator--trigger--click">
@@ -717,7 +718,7 @@
                                     <path d="M14,3c2.2,0,4,1.8,4,4c0,4-5.2,10-8,10S2,11,2,7c0-2.2,1.8-4,4-4c1,0,1.9,0.4,2.7,1L10,5.2L11.3,4C12.1,3.4,13,3,14,3 M14,1
 	c-1.5,0-2.9,0.6-4,1.5C8.9,1.6,7.5,1,6,1C2.7,1,0,3.7,0,7c0,5,6,12,10,12s10-7,10-12C20,3.7,17.3,1,14,1L14,1z"/>
                                 </svg>
-                                <span class="mobile-menu__indicator-counter">{{ totalItems }}</span>
+                                <span class="mobile-menu__indicator-counter">{{ totalItems()|default(0) }}</span>
                             </span>
                         <span class="mobile-menu__indicator-title">Wishlist</span>
                     </a>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,135 +1,157 @@
-version: '3.8'
+version: "3.8"
 
 services:
-    www:
-        build:
-            context: ./Rwayed
-            dockerfile: ../docker/server/Dockerfile
-        expose:
-            - "9000"
-            - "9003"
-        ports:
-            - "80:80"
-        working_dir: /var/www/html
-        volumes:
-            - ./Rwayed:/var/www/html
-            - ./docker/server/apache/sites-enabled:/etc/apache2/sites-enabled
-            - ./docker/server/php/php.ini:/usr/local/etc/php/conf.d/extra-php-config.ini
-        extra_hosts:
-            - host.docker.internal:host-gateway
-        depends_on:
-            - database
-        networks:
-            - inner_net
+  www:
+    build:
+      context: ./Rwayed
+      dockerfile: ../docker/server/Dockerfile
+    expose:
+      - "9000"
+      - "9003"
+    ports:
+      - "83:80"
+    working_dir: /var/www/html
+    volumes:
+      - ./Rwayed:/var/www/html
+      - ./docker/server/apache/sites-enabled:/etc/apache2/sites-enabled
+      - ./docker/server/php/php.ini:/usr/local/etc/php/conf.d/extra-php-config.ini
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    depends_on:
+      - database
+    networks:
+      - inner_net
 
-    www_admin:
-        build:
-            context: ./Rwayed_Admin
-            dockerfile: ../docker/server/Dockerfile
-        expose:
-            - "9000"
-            - "9003"
-        ports:
-            - "81:80"
-        working_dir: /var/www/html
-        volumes:
-            - ./Rwayed_Admin:/var/www/html
-            - ./docker/server/apache/sites-enabled:/etc/apache2/sites-enabled
-            - ./docker/server/php/php.ini:/usr/local/etc/php/conf.d/extra-php-config.ini
-        extra_hosts:
-            - host.docker.internal:host-gateway
-        depends_on:
-            - database
-        networks:
-            - inner_net
-    www_api:
-        build:
-            context: ./Rwayed_API
-            dockerfile: ../docker/server/Dockerfile
-        expose:
-            - "9000"
-            - "9003"
-        ports:
-            - "82:80" # Le port 82 est utilisé ici comme exemple, assurez-vous qu'il ne soit pas en conflit
-        working_dir: /var/www/html
-        volumes:
-            - ./Rwayed_API:/var/www/html # Chemin vers le dossier de votre API
-            - ./docker/server/apache/sites-enabled:/etc/apache2/sites-enabled
-            - ./docker/server/php/php.ini:/usr/local/etc/php/conf.d/extra-php-config.ini
-        extra_hosts:
-            - host.docker.internal:host-gateway
-        depends_on:
-            - database
-        networks:
-            - inner_net
-#    elasticsearch:
-#        image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0 # Utilisez la version qui convient à vos besoins
-#        environment:
-#            - discovery.type=single-node # Pour le développement, en production considérez une configuration de cluster
-#        ports:
-#            - "9200:9200" # Port par défaut d'Elasticsearch
-#            - "9300:9300" # Port pour la communication entre les nœuds
-#        networks:
-#            - inner_net
-#        volumes:
-#            - es_data:/usr/share/elasticsearch/data # Persiste les données d'Elasticsearch
-    minio:
-        image: minio/minio
-        volumes:
-            - minio_data:/data
-        ports:
-            - "9000:9000"
-            - "9001:9001"
-        environment:
-            MINIO_ROOT_USER: rwayed123       #!!! a les maitres dans .env.local
-            MINIO_ROOT_PASSWORD: rwayed123   #!!! a les maitres dans .env.local
-        command: server /data --console-address ":9001"
-        networks:
-            - inner_net
-    mailcatcher:
-        networks:
-            - inner_net
-        image: yappabe/mailcatcher
-        ports:
-            - "1025:1025"
-            - "1080:1080"
+  www_admin:
+    build:
+      context: ./Rwayed_Admin
+      dockerfile: ../docker/server/Dockerfile
+    expose:
+      - "9000"
+      - "9003"
+    ports:
+      - "81:80"
+    working_dir: /var/www/html
+    volumes:
+      - ./Rwayed_Admin:/var/www/html
+      - ./docker/server/apache/sites-enabled:/etc/apache2/sites-enabled
+      - ./docker/server/php/php.ini:/usr/local/etc/php/conf.d/extra-php-config.ini
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    depends_on:
+      - database
+    networks:
+      - inner_net
+  www_api:
+    build:
+      context: ./Rwayed_API
+      dockerfile: ../docker/server/Dockerfile
+    expose:
+      - "9000"
+      - "9003"
+    ports:
+      - "82:80" # Le port 82 est utilisé ici comme exemple, assurez-vous qu'il ne soit pas en conflit
+    working_dir: /var/www/html
+    volumes:
+      - ./Rwayed_API:/var/www/html # Chemin vers le dossier de votre API
+      - ./docker/server/apache/sites-enabled:/etc/apache2/sites-enabled
+      - ./docker/server/php/php.ini:/usr/local/etc/php/conf.d/extra-php-config.ini
+    extra_hosts:
+      - host.docker.internal:host-gateway
+    depends_on:
+      - database
+    networks:
+      - inner_net
+  #    elasticsearch:
+  #        image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0 # Utilisez la version qui convient à vos besoins
+  #        environment:
+  #            - discovery.type=single-node # Pour le développement, en production considérez une configuration de cluster
+  #        ports:
+  #            - "9200:9200" # Port par défaut d'Elasticsearch
+  #            - "9300:9300" # Port pour la communication entre les nœuds
+  #        networks:
+  #            - inner_net
+  #        volumes:
+  #            - es_data:/usr/share/elasticsearch/data # Persiste les données d'Elasticsearch
 
-    database:
-        healthcheck:
-            test: mysqladmin ping -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD
-            interval: 5s
-            retries: 5
-        image: mysql
-        volumes:
-            - db_data:/var/lib/mysql
-        ports:
-            - "3306:3306"
-        environment:
-            MYSQL_ROOT_PASSWORD: 'jC5#u!7r^aPm'
-            MYSQL_USER: 'user'
-            MYSQL_PASSWORD: 'P@ssw0rd!'
-            MYSQL_DATABASE: 'db_rwayed'
-        networks:
-            - inner_net
+  database:
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD
+      interval: 5s
+      retries: 5
+    image: mysql
+    volumes:
+      - db_data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: "jC5#u!7r^aPm"
+      MYSQL_USER: "user"
+      MYSQL_PASSWORD: "P@ssw0rd!"
+      MYSQL_DATABASE: "db_rwayed"
+    networks:
+      - inner_net
 
-    myadmin:
-        image: phpmyadmin/phpmyadmin:5
-        environment:
-            PMA_HOST: database
-        ports:
-            - "8080:80"
-        depends_on:
-            - database
-        networks:
-            - inner_net
-        volumes:
-            - db_admin_data:/var/www/html
+  myadmin:
+    image: phpmyadmin/phpmyadmin:5
+    environment:
+      PMA_HOST: database
+    ports:
+      - "8080:80"
+    depends_on:
+      - database
+    networks:
+      - inner_net
+    volumes:
+      - db_admin_data:/var/www/html
+
+  mailcatcher:
+    networks:
+      - inner_net
+    image: yappabe/mailcatcher
+    ports:
+      - "1025:1025"
+      - "1080:1080"
+
+  mercure:
+    networks:
+      - inner_net
+    image: dunglas/mercure
+    restart: unless-stopped
+    environment:
+      SERVER_NAME: ":80"
+      MERCURE_PUBLISHER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+      MERCURE_SUBSCRIBER_JWT_KEY: "!ChangeThisMercureHubJWTSecretKey!"
+      MERCURE_EXTRA_DIRECTIVES: "cors_origins http://localhost:8000"
+    command: /usr/bin/caddy run --config /etc/caddy/Caddyfile.dev
+    ports:
+      - "9797:80"
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+      #- ./docker/caddy/:/etc/caddy/
+
+  minio:
+    image: minio/minio
+    volumes:
+      - minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: rwayed123 #!!! a les maitres dans .env.local
+      MINIO_ROOT_PASSWORD: rwayed123 #!!! a les maitres dans .env.local
+    command: server /data --console-address ":9001"
+    networks:
+      - inner_net
 
 volumes:
-    es_data:
-    db_data:
-    db_admin_data:
-    minio_data:
+  es_data:
+  db_data:
+  db_admin_data:
+  minio_data:
+  caddy_data:
+  caddy_config:
 
 networks:
-    inner_net:
+  inner_net:


### PR DESCRIPTION
Ce commit inclut plusieurs mises à jour :
1. Ajout de TotalItemsExtension : Cette extension Twig permet de calculer le nombre total d'éléments dans la wishlist de l'utilisateur connecté et de l'afficher dans toutes les pages du projet. La classe TotalItemsExtension étend AbstractExtension et implémente ExtensionInterface. Elle utilise le service Security pour récupérer l'utilisateur connecté et le service EntityManager pour accéder à la base de données et compter le nombre d'éléments dans la wishlist.

2. Configuration de TotalItemsExtension dans services.yaml : J'ai configuré TotalItemsExtension en tant qu'extension Twig dans le fichier services.yaml afin qu'elle soit automatiquement chargée dans le système de templates.

3. Implémentation du protocole Mercure : J'ai configuré le schéma compose.yaml dans le projet rwayed ainsi que le fichier docker-compose.yml pour inclure les services nécessaires pour le protocole Mercure. De plus, j'ai défini les variables d'environnement nécessaires pour le bon fonctionnement de Mercure.

4. Correction du code selon la review de la PR 67 en plus des erreurs de syntaxe, les bugs de logique et les améliorations de la qualité du code.